### PR TITLE
chore: prettier ignore and README fixes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ dist
 node_modules
 .github
 .changeset
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
+[![Netlify Status](https://api.netlify.com/api/v1/badges/10d83a12-0f48-46d9-a25a-e967a785297e/deploy-status)](https://app.netlify.com/sites/nicholasnadeau/deploys)
+[![CI](https://github.com/engnadeau/site-nicholasnadeau-com/actions/workflows/ci.yaml/badge.svg)](https://github.com/engnadeau/site-nicholasnadeau-com/actions/workflows/ci.yaml)
+[![CodeQL](https://github.com/engnadeau/site-nicholasnadeau-com/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/engnadeau/site-nicholasnadeau-com/actions/workflows/github-code-scanning/codeql)
+[![Dependabot Updates](https://github.com/engnadeau/site-nicholasnadeau-com/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/engnadeau/site-nicholasnadeau-com/actions/workflows/dependabot/dependabot-updates)
+
+
 # Nicholas' Site
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/10d83a12-0f48-46d9-a25a-e967a785297e/deploy-status)](https://app.netlify.com/sites/nicholasnadeau/deploys)
 
 This project is based on [AstroWind](https://github.com/onwidget/astrowind), using `.astro` or `.md` files in the `src/pages/` directory to define routes by file name.
 

--- a/README.md
+++ b/README.md
@@ -3,24 +3,8 @@
 [![CodeQL](https://github.com/engnadeau/site-nicholasnadeau-com/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/engnadeau/site-nicholasnadeau-com/actions/workflows/github-code-scanning/codeql)
 [![Dependabot Updates](https://github.com/engnadeau/site-nicholasnadeau-com/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/engnadeau/site-nicholasnadeau-com/actions/workflows/dependabot/dependabot-updates)
 
-
 # Nicholas' Site
 
+This project uses `.astro` or `.md` files in the `src/pages/` directory to define routes by file name.
 
-This project is based on [AstroWind](https://github.com/onwidget/astrowind), using `.astro` or `.md` files in the `src/pages/` directory to define routes by file name.
-
-Static assets can be added in `public/` (for non-transforming assets) or `assets/` (for direct imports).
-
-## Commands
-
-Run these from the project root in the terminal:
-
-| Command             | Description                                |
-| ------------------- | ------------------------------------------ |
-| `npm install`       | Install dependencies                       |
-| `npm run dev`       | Start local dev server at `localhost:3000` |
-| `npm run build`     | Build for production to `./dist/`          |
-| `npm run preview`   | Preview production build locally           |
-| `npm run check`     | Check for project errors                   |
-| `npm run fix`       | Lint and format code with Prettier         |
-| `npm run astro ...` | Run Astro CLI commands (e.g., `astro add`) |
+Static assets can be added in `public/` (for non-transforming assets) or `src/assets/` (for direct imports and transformations).


### PR DESCRIPTION
- **chore: update .prettierignore to include pnpm-lock.yaml for consistent formatting and tracking**
- **docs: add status badges to README for Netlify, CI, CodeQL, and Dependabot for better visibility of project health**
- **docs: update README to clarify project structure and routing, and refine static asset locations**
