### PR TITLE
chore: standardize dependabot — monthly + 14d cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,26 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+# Managed via centralized policy rollout.
+# - monthly cadence to reduce noise
+# - 14d cooldown to mitigate supply-chain attacks (malicious versions yanked within days)
+# Security updates remain immediate.
 version: 2
 updates:
-  - package-ecosystem: "npm" # Package manager
-    directory: "/"           # Location of package manifests
-    schedule:
-      interval: "weekly"     # Check for updates weekly
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 14
+      semver-major-days: 14
+      semver-minor-days: 14
+      semver-patch-days: 14
+    open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 14
+      semver-major-days: 14
+      semver-minor-days: 14
+      semver-patch-days: 14
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,3 @@
-# Managed via centralized policy rollout.
-# - monthly cadence to reduce noise
-# - 14d cooldown to mitigate supply-chain attacks (malicious versions yanked within days)
-# Security updates remain immediate.
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -10,17 +6,9 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 14
-      semver-major-days: 14
-      semver-minor-days: 14
-      semver-patch-days: 14
-    open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
     cooldown:
       default-days: 14
-      semver-major-days: 14
-      semver-minor-days: 14
-      semver-patch-days: 14
-    open-pull-requests-limit: 10


### PR DESCRIPTION
Standardizes Dependabot **version updates** across all repos:

- **Cadence:** monthly (reduces PR noise)
- **Cooldown:** 14 days on major/minor/patch (mitigates supply-chain attacks where a malicious version is published and yanked within days)
- **Ecosystems:** `github-actions` + auto-detected from manifest files in this repo

Security updates remain immediate (the cooldown setting only affects version updates).

Generated by automated rollout.
