### PR TITLE
fix: remove dead About link from footer

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -12,7 +12,6 @@ export const footerData = {
   secondaryLinks: [
     { text: 'Home', href: '/' },
     { text: 'Posts', href: '/#posts' },
-    { text: 'About', href: '/#about' },
   ],
   socialLinks: [
     { ariaLabel: 'RSS', icon: 'tabler:rss', href: getAsset('/rss.xml') },


### PR DESCRIPTION
## Summary

The footer's secondary nav contained an `About` link pointing at `/#about`, but no element with `id="about"` exists anywhere on the site. The link was dead — clicking it did nothing.

Removed the entry from `footerData.secondaryLinks` in `src/navigation.ts`.

## Verification

- `pnpm check` — 0 errors, 0 warnings (the single `_image` hint in `src/utils/images.ts` is pre-existing and unrelated)
- `pnpm build` — 129 pages built successfully
- `grep -rl '#about' dist/` — no matches, confirming the anchor is gone from all built output

🤖 Generated with [Claude Code](https://claude.com/claude-code)